### PR TITLE
Install on python 3.6 or higher

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     packages=setuptools.find_packages(),
-    python_requires=">=3.9",
+    python_requires=">=3.6",
 )


### PR DESCRIPTION
As tested, AIS works with lower versions of python and would be better to make it available for these versions.